### PR TITLE
Simplify value lookups with default_procedure_for pattern

### DIFF
--- a/lib/halitosis/attributes.rb
+++ b/lib/halitosis/attributes.rb
@@ -27,7 +27,13 @@ module Halitosis
       # @return [Halitosis::Attributes::Field]
       #
       def attribute(name, options = {}, &procedure)
-        procedure ||= default_procedure_for(name) unless options.key?(:value)
+        unless procedure
+          if options[:value].is_a?(Symbol)
+            procedure = default_procedure_for(options.delete(:value))
+          elsif !options.key?(:value)
+            procedure = default_procedure_for(name)
+          end
+        end
         fields.add(Field.new(name, options, procedure))
       end
     end

--- a/lib/halitosis/attributes.rb
+++ b/lib/halitosis/attributes.rb
@@ -27,6 +27,7 @@ module Halitosis
       # @return [Halitosis::Attributes::Field]
       #
       def attribute(name, options = {}, &procedure)
+        procedure ||= default_procedure_for(name) unless options.key?(:value)
         fields.add(Field.new(name, options, procedure))
       end
     end

--- a/lib/halitosis/base.rb
+++ b/lib/halitosis/base.rb
@@ -24,6 +24,16 @@ module Halitosis
       def collection?
         false
       end
+
+      # Returns the default proc used to resolve a field value when no block
+      # or :value option is given. Override in submodules to change the source.
+      #
+      # @param name [Symbol] the field name
+      # @return [Proc]
+      #
+      def default_procedure_for(name)
+        proc { public_send(name) }
+      end
     end
 
     module InstanceMethods

--- a/lib/halitosis/identifiers.rb
+++ b/lib/halitosis/identifiers.rb
@@ -21,7 +21,13 @@ module Halitosis
           raise InvalidField, "You can only define one identifier per serializer"
         end
 
-        procedure ||= default_procedure_for(name) unless options.key?(:value)
+        unless procedure
+          if options[:value].is_a?(Symbol)
+            procedure = default_procedure_for(options.delete(:value))
+          elsif !options.key?(:value)
+            procedure = default_procedure_for(name)
+          end
+        end
         fields.add(Field.new(name, options, procedure))
       end
     end

--- a/lib/halitosis/identifiers.rb
+++ b/lib/halitosis/identifiers.rb
@@ -21,6 +21,7 @@ module Halitosis
           raise InvalidField, "You can only define one identifier per serializer"
         end
 
+        procedure ||= default_procedure_for(name) unless options.key?(:value)
         fields.add(Field.new(name, options, procedure))
       end
     end

--- a/lib/halitosis/meta.rb
+++ b/lib/halitosis/meta.rb
@@ -12,6 +12,13 @@ module Halitosis
       # @return [Halitosis::Meta::Field]
       #
       def meta(name, **options, &procedure)
+        unless procedure
+          if options[:value].is_a?(Symbol)
+            procedure = default_procedure_for(options.delete(:value))
+          elsif !options.key?(:value)
+            procedure = default_procedure_for(name)
+          end
+        end
         fields.add(Field.new(name, options, procedure))
       end
     end

--- a/lib/halitosis/resource.rb
+++ b/lib/halitosis/resource.rb
@@ -27,28 +27,13 @@ module Halitosis
         alias_method name, :resource
       end
 
-      # Override standard identifier field for resource-based serializers
+      # For resource-based serializers, delegate to the resource by default
       #
-      # @param name [Symbol, String] name of the identifier
-      # @param options [nil, Hash] identifier options for field
+      # @param name [Symbol] the field name
+      # @return [Proc]
       #
-      def identifier(name, options = {}, &procedure)
-        unless procedure || options.key?(:value)
-          procedure = proc { resource.public_send(name) }
-        end
-        super(name, options, &procedure)
-      end
-
-      # Override standard attribute field for resource-based serializers
-      #
-      # @param name [Symbol, String] name of the attribute
-      # @param options [nil, Hash] attribute options for field
-      #
-      def attribute(name, options = {}, &procedure)
-        unless procedure || options.key?(:value)
-          procedure = proc { resource.public_send(name) }
-        end
-        super(name, options, &procedure)
+      def default_procedure_for(name)
+        proc { resource.public_send(name) }
       end
     end
 

--- a/spec/halitosis/attributes_spec.rb
+++ b/spec/halitosis/attributes_spec.rb
@@ -61,6 +61,22 @@ RSpec.describe Halitosis::Attributes do
 
         expect(serializer.attributes).to eq(foo: "bar")
       end
+
+      it "delegates to the serializer instance when no value or block is given" do
+        klass.attribute(:foo)
+
+        allow(serializer).to receive(:foo).and_return("bar")
+
+        expect(serializer.attributes).to eq(foo: "bar")
+      end
+
+      it "delegates to the named method when value is a symbol" do
+        klass.attribute(:foo, value: :bar)
+
+        allow(serializer).to receive(:bar).and_return("baz")
+
+        expect(serializer.attributes).to eq(foo: "baz")
+      end
     end
   end
 end

--- a/spec/halitosis/identifiers_spec.rb
+++ b/spec/halitosis/identifiers_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Halitosis::Identifiers do
 
         expect(serializer.identifiers).to eq(foo: "bar")
       end
+
+      it "delegates to the serializer instance when no value or block is given" do
+        klass.identifier(:foo)
+
+        allow(serializer).to receive(:foo).and_return("bar")
+
+        expect(serializer.identifiers).to eq(foo: "bar")
+      end
+
+      it "delegates to the named method when value is a symbol" do
+        klass.identifier(:foo, value: :bar)
+
+        allow(serializer).to receive(:bar).and_return("baz")
+
+        expect(serializer.identifiers).to eq(foo: "baz")
+      end
     end
   end
 end

--- a/spec/halitosis/meta_spec.rb
+++ b/spec/halitosis/meta_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe Halitosis::Meta do
 
         expect(serializer.meta).to eq(foo: "bar")
       end
+
+      it "delegates to the serializer instance when no value or block is given" do
+        klass.meta(:foo)
+
+        allow(serializer).to receive(:foo).and_return("bar")
+
+        expect(serializer.meta).to eq(foo: "bar")
+      end
+
+      it "delegates to the named method when value is a symbol" do
+        klass.meta(:foo, value: :bar)
+
+        allow(serializer).to receive(:bar).and_return("baz")
+
+        expect(serializer.meta).to eq(foo: "baz")
+      end
     end
   end
 end

--- a/spec/halitosis/resource_spec.rb
+++ b/spec/halitosis/resource_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe Halitosis::Resource do
         )
       end
 
+      it "delegates to the named resource method when value is a symbol" do
+        klass.attribute(:bar, value: :baz)
+
+        allow(resource).to receive(:baz).and_return("qux")
+
+        expect(serializer.render).to eq(
+          foo: {bar: "qux"}
+        )
+      end
+
       it "evaluates the block in the context of the serializer" do
         def serializer.bar
           object_id


### PR DESCRIPTION
- **Override value getter instead of identifier/attribute methods**
- **Use default_procedure_for with value option**
- **Delegate meta lookups to the resource**
