### PR TITLE
Handle empty exception error blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,6 +1454,8 @@ en:
 
 Halitosis renders these errors using `ExceptionSerializer`. For custom rescue logic, use `ExceptionSerializer.build` to define the response inline:
 
+> **Note:** Always use `{ }` rather than `do...end` for the `.build` block. Ruby's block precedence rules mean a `do...end` block binds to the outer `render` call, not to `.build`, and no fields will be defined.
+
 ```ruby
 rescue_from Halitosis::InvalidQueryParameter do |error|
   render renderable: Halitosis::ExceptionSerializer.build(error) {
@@ -1540,6 +1542,8 @@ This produces:
 `Halitosis::ExceptionSerializer` serializes a single exception to a `{ errors: [...] }` envelope. It is used internally by Halitosis to render query parameter errors.
 
 Use `.build` to define fields inline without subclassing. Blocks execute in serializer instance context, so `error` refers to the exception:
+
+> **Note:** Always use `{ }` rather than `do...end` for the `.build` block. Ruby's block precedence rules mean a `do...end` block binds to the outer `render` call, not to `.build`, and no fields will be defined.
 
 ```ruby
 render renderable: Halitosis::ExceptionSerializer.build(error) {

--- a/README.md
+++ b/README.md
@@ -1494,7 +1494,7 @@ This produces:
 
 The `code` is omitted when the error type is not a symbol. The `source` pointer is omitted for base errors (errors on `:base` or with no attribute). The `param` option sets the leading path segment — use `"data/attributes"` for JSON:API-compliant request bodies.
 
-To add extra JSON:API-style error fields, subclass `Halitosis::ErrorSerializer` and pass the subclass via `error_serializer_class`:
+To add extra JSON:API-style error fields, subclass `Halitosis::ErrorSerializer` and pass the subclass via `error_serializer_class`. Only `attribute`, `link`, and `meta` fields may be defined — `identifier`, `permission`, `relationship`, and other field types are not supported:
 
 ```ruby
 class MyErrorSerializer < Halitosis::ErrorSerializer
@@ -1541,7 +1541,7 @@ This produces:
 
 `Halitosis::ExceptionSerializer` serializes a single exception to a `{ errors: [...] }` envelope. It is used internally by Halitosis to render query parameter errors.
 
-Use `.build` to define fields inline without subclassing. Blocks execute in serializer instance context, so `error` refers to the exception:
+Use `.build` to define fields inline without subclassing. Blocks execute in serializer instance context, so `error` refers to the exception. `.build` raises `ArgumentError` if called without a block or if the block defines no fields. Only `attribute`, `link`, and `meta` fields are supported:
 
 > **Note:** Always use `{ }` rather than `do...end` for the `.build` block. Ruby's block precedence rules mean a `do...end` block binds to the outer `render` call, not to `.build`, and no fields will be defined.
 
@@ -1555,10 +1555,10 @@ render renderable: Halitosis::ExceptionSerializer.build(error) {
 }, status: :unauthorized
 ```
 
-For a reusable error class, subclass `ExceptionSerializer::ErrorEntry` — the same DSL methods are available:
+For a reusable error class, subclass `Halitosis::ErrorEntry` — the same DSL methods are available:
 
 ```ruby
-class UnauthorizedEntry < Halitosis::ExceptionSerializer::ErrorEntry
+class UnauthorizedEntry < Halitosis::ErrorEntry
   code   { "unauthorized" }
   title  { "Unauthorized" }
   detail { error.message }

--- a/lib/halitosis/rails/error_entry.rb
+++ b/lib/halitosis/rails/error_entry.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Halitosis
+  # Shared base for JSON:API error entry serializers.
+  # Only +attribute+, +link+, and +meta+ fields may be defined on a subclass.
+  class ErrorEntry
+    include Halitosis::Base
+    include Halitosis::Attributes
+    include Halitosis::Links
+    include Halitosis::Meta
+
+    # Class-level DSL shortcuts for JSON:API error fields.
+    # Thin wrappers over the standard Halitosis +attribute+ DSL.
+    module ClassMethods
+      def id(&blk) = attribute(:id, &blk)
+      def code(&blk) = attribute(:code, &blk)
+      def title(&blk) = attribute(:title, &blk)
+      def status(&blk) = attribute(:status, &blk)
+      def detail(&blk) = attribute(:detail, &blk)
+
+      def source_pointer(&blk)
+        define_method(:_source_value, &blk)
+        private :_source_value
+        attribute(:source) { {pointer: _source_value} }
+      end
+
+      def source_parameter(&blk)
+        define_method(:_source_value, &blk)
+        private :_source_value
+        attribute(:source) { {parameter: _source_value} }
+      end
+
+      def source_header(&blk)
+        define_method(:_source_value, &blk)
+        private :_source_value
+        attribute(:source) { {header: _source_value} }
+      end
+    end
+
+    extend ClassMethods
+
+    required_option :error
+  end
+end

--- a/lib/halitosis/rails/error_serializer.rb
+++ b/lib/halitosis/rails/error_serializer.rb
@@ -16,41 +16,9 @@ module Halitosis
   #     param: "article",
   #     error_serializer_class: MyErrorSerializer
   #   ), status: :unprocessable_entity
-  class ErrorSerializer
-    include Halitosis
-
-    # Class-level DSL shortcuts for JSON:API error fields.
-    # Thin wrappers over the standard Halitosis +attribute+ DSL.
-    # Shared with +ExceptionSerializer::ErrorEntry+.
-    module ClassMethods
-      def id(&blk) = attribute(:id, &blk)
-      def code(&blk) = attribute(:code, &blk)
-      def title(&blk) = attribute(:title, &blk)
-      def status(&blk) = attribute(:status, &blk)
-      def detail(&blk) = attribute(:detail, &blk)
-
-      def source_pointer(&blk)
-        define_method(:_source_value, &blk)
-        private :_source_value
-        attribute(:source) { {pointer: _source_value} }
-      end
-
-      def source_parameter(&blk)
-        define_method(:_source_value, &blk)
-        private :_source_value
-        attribute(:source) { {parameter: _source_value} }
-      end
-
-      def source_header(&blk)
-        define_method(:_source_value, &blk)
-        private :_source_value
-        attribute(:source) { {header: _source_value} }
-      end
-    end
-
-    extend ClassMethods
-
-    required_option :error
+  #
+  # Only +attribute+, +link+, and +meta+ fields may be defined on an error serializer.
+  class ErrorSerializer < ErrorEntry
     required_option :param
 
     attribute(:code, unless: -> { !error.type.is_a?(Symbol) }) { error_code }

--- a/lib/halitosis/rails/exception_serializer.rb
+++ b/lib/halitosis/rails/exception_serializer.rb
@@ -15,34 +15,28 @@ module Halitosis
   #     link(:about) { "https://docs.example.com/errors/unauthorized" }
   #   }, status: :unauthorized
   #
-  # Or subclass +ExceptionSerializer::ErrorEntry+ for a reusable class:
+  # Or subclass +Halitosis::ErrorEntry+ for a reusable class:
   #
   # @example
-  #   class AuthEntry < Halitosis::ExceptionSerializer::ErrorEntry
+  #   class AuthEntry < Halitosis::ErrorEntry
   #     code  { "unauthorized" }
   #     title { "Unauthorized" }
   #   end
   class ExceptionSerializer < ErrorsSerializer
-    # Alias to +ErrorSerializer::ClassMethods+ for backward compatibility.
-    ClassMethods = ErrorSerializer::ClassMethods
-
-    # Base Halitosis serializer for a single entry in the +errors+ array.
-    # Carries the +ClassMethods+ DSL shortcuts. Subclass to build reusable
-    # error entries, or use +ExceptionSerializer.build+ for inline definitions.
-    class ErrorEntry
-      include Halitosis
-      extend ClassMethods
-
-      required_option :error
-    end
-
     def self.build(exception, &dsl_block)
-      entry_class = Class.new(ErrorEntry)
-      entry_class.class_eval(&dsl_block) if dsl_block
+      raise ArgumentError, "#{name}.build requires a block" unless dsl_block
+
+      entry_class = Class.new(Halitosis::ErrorEntry)
+      entry_class.class_eval(&dsl_block)
+
+      if entry_class.fields.empty?
+        raise ArgumentError, "#{name}.build block must define at least one attribute, link, or meta field"
+      end
+
       new(exception, error_serializer_class: entry_class)
     end
 
-    def initialize(exception, error_serializer_class: ErrorEntry, **options)
+    def initialize(exception, error_serializer_class: Halitosis::ErrorEntry, **options)
       super([exception], param: nil, error_serializer_class: error_serializer_class, **options)
     end
   end

--- a/lib/halitosis/rails/parameter_exception_serializer.rb
+++ b/lib/halitosis/rails/parameter_exception_serializer.rb
@@ -2,7 +2,7 @@
 
 module Halitosis
   class ParameterExceptionSerializer < ExceptionSerializer
-    class ErrorEntry < ExceptionSerializer::ErrorEntry
+    class ErrorEntry < Halitosis::ErrorEntry
       attribute(:code, unless: -> { translate("code").nil? }) { translate("code") }
       attribute(:title) { translate("title", default: error.class.name.demodulize.titleize) }
       attribute(:detail) { error.message }

--- a/lib/halitosis/railtie.rb
+++ b/lib/halitosis/railtie.rb
@@ -28,6 +28,7 @@ end
 
 require_relative "error_handling"
 require_relative "rails/renderable"
+require_relative "rails/error_entry"
 require_relative "rails/error_serializer"
 require_relative "rails/errors_serializer"
 require_relative "rails/exception_serializer"

--- a/spec/halitosis/rails/error_entry_spec.rb
+++ b/spec/halitosis/rails/error_entry_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+return unless defined?(Rails)
+
+RSpec.describe Halitosis::ErrorEntry, :rails do
+  let(:exception) { StandardError.new("Something went wrong") }
+
+  it "raises MissingOption when error is not provided" do
+    expect { described_class.new }.to raise_error(Halitosis::MissingOption)
+  end
+
+  it "renders an empty hash when no fields are defined" do
+    result = described_class.new(error: exception).as_json
+
+    expect(result).to eq({})
+  end
+
+  it "does not support identifier" do
+    expect { described_class.identifier(:id) }.to raise_error(NoMethodError)
+  end
+
+  it "does not support permission" do
+    expect { described_class.permission(:read) { true } }.to raise_error(NoMethodError)
+  end
+
+  it "does not support relationship" do
+    expect { described_class.relationship(:author) { nil } }.to raise_error(NoMethodError)
+  end
+
+  describe "ClassMethods" do
+    subject(:entry_class) { Class.new(described_class) }
+
+    %i[id code title status detail].each do |field|
+      describe "##{field}" do
+        it "defines a #{field} attribute" do
+          entry_class.public_send(field) { field.to_s.upcase }
+
+          result = entry_class.new(error: exception).as_json
+
+          expect(result[field.to_s]).to eq(field.to_s.upcase)
+        end
+      end
+    end
+
+    describe "#source_pointer" do
+      it "renders source with pointer key" do
+        entry_class.source_pointer { "/data/attributes/title" }
+
+        result = entry_class.new(error: exception).as_json
+
+        expect(result["source"]).to eq("pointer" => "/data/attributes/title")
+      end
+    end
+
+    describe "#source_parameter" do
+      it "renders source with parameter key" do
+        entry_class.source_parameter { "sort" }
+
+        result = entry_class.new(error: exception).as_json
+
+        expect(result["source"]).to eq("parameter" => "sort")
+      end
+    end
+
+    describe "#source_header" do
+      it "renders source with header key" do
+        entry_class.source_header { "Authorization" }
+
+        result = entry_class.new(error: exception).as_json
+
+        expect(result["source"]).to eq("header" => "Authorization")
+      end
+    end
+
+    it "exposes the exception as `error` in attribute blocks" do
+      entry_class.detail { error.message }
+
+      result = entry_class.new(error: exception).as_json
+
+      expect(result["detail"]).to eq("Something went wrong")
+    end
+  end
+end

--- a/spec/halitosis/rails/error_serializer_spec.rb
+++ b/spec/halitosis/rails/error_serializer_spec.rb
@@ -84,4 +84,18 @@ RSpec.describe Halitosis::ErrorSerializer, :rails do
       expect { described_class.new(error: error) }.to raise_error(Halitosis::MissingOption)
     end
   end
+
+  describe "field restrictions" do
+    it "does not support identifier" do
+      expect { described_class.identifier(:id) }.to raise_error(NoMethodError)
+    end
+
+    it "does not support permission" do
+      expect { described_class.permission(:read) { true } }.to raise_error(NoMethodError)
+    end
+
+    it "does not support relationship" do
+      expect { described_class.relationship(:author) { nil } }.to raise_error(NoMethodError)
+    end
+  end
 end

--- a/spec/halitosis/rails/exception_serializer_spec.rb
+++ b/spec/halitosis/rails/exception_serializer_spec.rb
@@ -5,77 +5,19 @@ return unless defined?(Rails)
 RSpec.describe Halitosis::ExceptionSerializer, :rails do
   let(:exception) { StandardError.new("Something went wrong") }
 
-  describe "::ErrorEntry" do
-    it "raises MissingOption when error is not provided" do
-      expect { described_class::ErrorEntry.new }.to raise_error(Halitosis::MissingOption)
-    end
-
-    it "renders an empty hash when no fields are defined" do
-      result = described_class::ErrorEntry.new(error: exception).as_json
-
-      expect(result).to eq({})
-    end
-  end
-
-  describe "::ClassMethods" do
-    subject(:entry_class) { Class.new(described_class::ErrorEntry) }
-
-    %i[id code title status detail].each do |field|
-      describe "##{field}" do
-        it "defines a #{field} attribute" do
-          entry_class.public_send(field) { field.to_s.upcase }
-
-          result = entry_class.new(error: exception).as_json
-
-          expect(result[field.to_s]).to eq(field.to_s.upcase)
-        end
-      end
-    end
-
-    describe "#source_pointer" do
-      it "renders source with pointer key" do
-        entry_class.source_pointer { "/data/attributes/title" }
-
-        result = entry_class.new(error: exception).as_json
-
-        expect(result["source"]).to eq("pointer" => "/data/attributes/title")
-      end
-    end
-
-    describe "#source_parameter" do
-      it "renders source with parameter key" do
-        entry_class.source_parameter { "sort" }
-
-        result = entry_class.new(error: exception).as_json
-
-        expect(result["source"]).to eq("parameter" => "sort")
-      end
-    end
-
-    describe "#source_header" do
-      it "renders source with header key" do
-        entry_class.source_header { "Authorization" }
-
-        result = entry_class.new(error: exception).as_json
-
-        expect(result["source"]).to eq("header" => "Authorization")
-      end
-    end
-
-    it "exposes the exception as `error` in attribute blocks" do
-      entry_class.detail { error.message }
-
-      result = entry_class.new(error: exception).as_json
-
-      expect(result["detail"]).to eq("Something went wrong")
-    end
-  end
-
   describe ".build" do
     it "returns an ExceptionSerializer instance" do
-      result = described_class.build(exception)
+      result = described_class.build(exception) { code { "error" } }
 
       expect(result).to be_a(described_class)
+    end
+
+    it "raises ArgumentError when called without a block" do
+      expect { described_class.build(exception) }.to raise_error(ArgumentError, /requires a block/)
+    end
+
+    it "raises ArgumentError when the block defines no fields" do
+      expect { described_class.build(exception) {} }.to raise_error(ArgumentError, /at least one attribute, link, or meta field/)
     end
 
     it "wraps the exception in a single-element errors array" do
@@ -93,12 +35,6 @@ RSpec.describe Halitosis::ExceptionSerializer, :rails do
       error_object = result["errors"].first
       expect(error_object["code"]).to eq("unauthorized")
       expect(error_object["detail"]).to eq("Something went wrong")
-    end
-
-    it "renders an empty error entry when no fields are defined" do
-      result = described_class.build(exception).as_json
-
-      expect(result["errors"]).to eq([{}])
     end
 
     context "with source shortcuts" do
@@ -136,7 +72,7 @@ RSpec.describe Halitosis::ExceptionSerializer, :rails do
     end
 
     it "accepts a custom error_serializer_class" do
-      custom_class = Class.new(described_class::ErrorEntry) do
+      custom_class = Class.new(Halitosis::ErrorEntry) do
         code { "custom" }
       end
 

--- a/spec/integrations/exception_serializer_spec.rb
+++ b/spec/integrations/exception_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "ExceptionSerializer", :rails do
     end
 
     let(:entry_class) do
-      Class.new(Halitosis::ExceptionSerializer::ErrorEntry) do
+      Class.new(Halitosis::ErrorEntry) do
         code { "unauthorized" }
         title { "Unauthorized" }
         detail { error.message }


### PR DESCRIPTION
- **Add instructions to prevent empty builder**
- **Extract Halitosis::ErrorEntry serializer**
